### PR TITLE
Remove the URL from the handler box

### DIFF
--- a/src/AVIFBuilder.cpp
+++ b/src/AVIFBuilder.cpp
@@ -156,7 +156,7 @@ avif::FileBox AVIFBuilder::buildFileBox() {
     { // fill HandlerBox
       HandlerBox& handlerBox = metaBox.handlerBox;
       handlerBox.setFullBoxHeader(0u, 0u);
-      handlerBox.name = "cavif - https://github.com/link-u/cavif";
+      handlerBox.name = "cavif";
       handlerBox.handler = "pict";
     }
   }


### PR DESCRIPTION
Reduces every image by 34 bytes.