### PR TITLE
full color rangeの扱いをなおした

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `--transfer-characteristics 13` (sRGB/sYCC)
     - `--matrix-coefficients 5` (sYCC)
 - All of `--color-primaries`, `--transfer-characteristics` and `--matrix-coefficients` nor none of them must be set.
+- `--enable-full-color-range` is now default, as mentioned in [ISO/IEC 23000-22:2019/Amd 2:2021](https://www.iso.org/standard/81634.html).
 - [Use SingleItemTypeReferenceBox instead of SingleItemTypeReferenceBoxLarge](https://github.com/link-u/cavif/commit/e271be5eddf1259d7a34315ece967a5e95766f49) to make images smaller.
 
 ### Fixed

--- a/doc/ja_JP/usage.md
+++ b/doc/ja_JP/usage.md
@@ -291,8 +291,8 @@ AV1のプロファイルを指定する。[プロファイルごとに使える�
 
 ### 色域
 
- - `--disable-full-color-range`（初期値）
- - `--enable-full-color-range`
+- `--enable-full-color-range`（初期値） 
+- `--disable-full-color-range`
 
 例えば通常の8bitのYUVのフォーマットでは、Yの値として16-235、UとVの値として16-240しか使わないが、このフラグをenableにすると0-255のすべてを使うようになる。10/12ビットでも同様。デフォルトではfalse。
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -203,8 +203,8 @@ clipp::group Config::createCommandLineFlags() {
       option("--profile").doc("AV1 Profile(0=base, 1=high, 2=professional)") & integer("0=base(default), 1=high, 2=professional", aom.g_profile),
       option("--pix-fmt").doc("Pixel format of output image") & (parameter("yuv420").set(pixFmt, AOM_IMG_FMT_I420).doc("YUV420 format (default)") | parameter("yuv422").set(pixFmt, AOM_IMG_FMT_I422).doc("YUV422 format") | parameter("yuv444").set(pixFmt, AOM_IMG_FMT_I444).doc("YUV444 format (recommended for lossless images)")),
       option("--bit-depth").doc("Bit depth of output image") & (parameter("8").set(aom.g_bit_depth, AOM_BITS_8).doc("8bits per color, 24bits per pixel (default)") | parameter("10").set(aom.g_bit_depth, AOM_BITS_10).doc("10bits per color, 30bits per pixel") | parameter("12").set(aom.g_bit_depth, AOM_BITS_12).doc("12bits per color, 36bits per pixel")),
-      option("--disable-full-color-range").doc("Use limited YUV color range (default)").set(fullColorRange, false),
-      option("--enable-full-color-range").doc("Use full YUV color range").set(fullColorRange, true)
+      option("--disable-full-color-range").doc("Use limited YUV color range").set(fullColorRange, false),
+      option("--enable-full-color-range").doc("Use full YUV color range (default)").set(fullColorRange, true)
   );
 
   // trade-offs between speed and quality.
@@ -395,16 +395,15 @@ numbers.
 }
 
 std::optional<avif::img::ColorProfile> Config::calcColorProfile() const {
+  avif::img::ColorProfile profile;
+  profile.cicp = std::make_optional<avif::ColourInformationBox::CICP>();
   if(colorPrimaries.has_value() && transferCharacteristics.has_value() && matrixCoefficients.has_value()) {
-    avif::img::ColorProfile profile;
-    profile.cicp = std::make_optional<avif::ColourInformationBox::CICP>();
     profile.cicp->colourPrimaries = static_cast<uint16_t>(colorPrimaries.value());
     profile.cicp->transferCharacteristics = static_cast<uint16_t>(transferCharacteristics.value());
     profile.cicp->colourPrimaries = static_cast<uint16_t>(colorPrimaries.value());
-    profile.cicp->fullRangeFlag = fullColorRange;
-    return profile;
   }
-  return {};
+  profile.cicp->fullRangeFlag = fullColorRange;
+  return profile;
 }
 
 void Config::modify(aom_codec_ctx_t* aom, avif::img::ColorProfile const& colorProfile) {

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -98,7 +98,7 @@ public:
   bool lossless = false;
   bool enableCDEF = false;
   bool enableRestoration = false;
-  bool fullColorRange = false;
+  bool fullColorRange = true;
   aom_superblock_size_t superblockSize = AOM_SUPERBLOCK_SIZE_DYNAMIC;
   aom_tune_metric tune = AOM_TUNE_SSIM;
   std::string vmafModelPath = "/usr/share/cavif/model/vmaf_v0.6.1.pkl";

--- a/src/img/Conversion.hpp
+++ b/src/img/Conversion.hpp
@@ -144,7 +144,8 @@ void convert(Config& config, avif::img::Image<rgbBits>& src, aom_image& dst) {
         config.pixFmt :
         static_cast<aom_img_fmt_t>(config.pixFmt | static_cast<unsigned int>(AOM_IMG_FMT_HIGHBITDEPTH));
   aom_img_alloc(&dst, pixFmt, src.width(), src.height(), 1);
-  dst.range = config.fullColorRange ? AOM_CR_FULL_RANGE : AOM_CR_STUDIO_RANGE;
+  avif::ColourInformationBox::CICP const cicp = src.colorProfile().cicp.value_or(avif::ColourInformationBox::CICP());
+  dst.range = cicp.fullRangeFlag ? AOM_CR_FULL_RANGE : AOM_CR_STUDIO_RANGE;
   dst.monochrome = config.codec.monochrome ? 1 : 0;
   dst.bit_depth = config.codec.g_bit_depth;
 


### PR DESCRIPTION
Fix #219 

- フラグから計算したCICPの値ではなくconfigの値を直接使ってしまってるのを直した
- ISOの規格の変更に合わせてfull rangeをデフォルトにした

@ryou-kawabata というわけでこちらが答えになります。

こんな感じ。市松模様、見えないでしょ？

![Screenshot from 2022-06-08 12-07-29](https://user-images.githubusercontent.com/51456946/172523220-5531572e-2075-4938-b25f-dec611e1cd77.png)
